### PR TITLE
No mm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.vscode/

--- a/backbone.py
+++ b/backbone.py
@@ -11,9 +11,9 @@ from functools import partial
 from timm.models.layers import DropPath, to_2tuple, trunc_normal_
 from timm.models.registry import register_model
 from timm.models.vision_transformer import _cfg
-from mmseg.models.builder import BACKBONES
-from mmseg.utils import get_root_logger
-from mmcv.runner import load_checkpoint
+# from mmseg.models.builder import BACKBONES
+# from mmseg.utils import get_root_logger
+# from mmcv.runner import load_checkpoint
 import math
 
 
@@ -471,4 +471,3 @@ class mit_b5(MixVisionTransformer):
             patch_size=4, embed_dims=[64, 128, 320, 512], num_heads=[1, 2, 5, 8], mlp_ratios=[4, 4, 4, 4],
             qkv_bias=True, norm_layer=partial(nn.LayerNorm, eps=1e-6), depths=[3, 6, 40, 3], sr_ratios=[8, 4, 2, 1],
             drop_rate=0.0, drop_path_rate=0.1)
-            

--- a/decode_head.py
+++ b/decode_head.py
@@ -2,11 +2,12 @@ from abc import ABCMeta, abstractmethod
 
 import torch
 import torch.nn as nn
-from mmcv.cnn import normal_init
-from mmcv.runner import auto_fp16, force_fp32
 
-from mmseg.core import build_pixel_sampler
-from mmseg.ops import resize
+# from mmcv.cnn import normal_init
+# from mmcv.runner import auto_fp16, force_fp32
+
+# from mmseg.core import build_pixel_sampler
+# from mmseg.ops import resize
 
 
 class BaseDecodeHead(nn.Module, metaclass=ABCMeta):
@@ -160,7 +161,7 @@ class BaseDecodeHead(nn.Module, metaclass=ABCMeta):
 
         return inputs
 
-    @auto_fp16()
+    # @auto_fp16()
     @abstractmethod
     def forward(self, inputs):
         """Placeholder of forward function."""
@@ -364,7 +365,7 @@ class BaseDecodeHead_clips(nn.Module, metaclass=ABCMeta):
 
         return inputs
 
-    @auto_fp16()
+    # @auto_fp16()
     @abstractmethod
     def forward(self, inputs):
         """Placeholder of forward function."""
@@ -567,7 +568,7 @@ class BaseDecodeHead_clips_flow(nn.Module, metaclass=ABCMeta):
 
         return inputs
 
-    @auto_fp16()
+    # @auto_fp16()
     @abstractmethod
     def forward(self, inputs):
         """Placeholder of forward function."""

--- a/full_model.py
+++ b/full_model.py
@@ -2,19 +2,19 @@ import os
 import numpy as np
 import torch.nn as nn
 import torch
-from mmcv.cnn import ConvModule, DepthwiseSeparableConvModule
+# from mmcv.cnn import ConvModule, DepthwiseSeparableConvModule
 from collections import OrderedDict
-from mmseg.ops import resize
-from builder import HEADS
+# from mmseg.ops import resize
+# from builder import HEADS
 from decode_head import BaseDecodeHead, BaseDecodeHead_clips, BaseDecodeHead_clips_flow
-from mmseg.models.utils import *
+# from mmseg.models.utils import *
 import attr
 from IPython import embed
 from stabilization_attention import BasicLayer3d3
 import cv2
 from networks import *
 import warnings
-from mmcv.utils import Registry, build_from_cfg
+# from mmcv.utils import Registry, build_from_cfg
 from torch import nn
 from backbone import *
 from stabilization_network import *
@@ -23,21 +23,21 @@ from collections import OrderedDict
 class NVDS(nn.Module):
     def __init__(self,use_pretrain='False'):
         super().__init__()
-        
+
         self.backbone = mit_b5()
         self.seq_len = 4
         self.use_pretrain = use_pretrain
 
         if self.use_pretrain is True:
             self.backbone.init_weights('/xxx/mit_b5.pth')
-        
+
         old_conv = self.backbone.patch_embed1.proj
         new_conv = nn.Conv2d(old_conv.in_channels + 1, old_conv.out_channels, kernel_size=old_conv.kernel_size, stride=old_conv.stride, padding=old_conv.padding)
-        
+
         new_conv.weight[:, :3, :, :].data.copy_(old_conv.weight.clone())
         self.backbone.patch_embed1.proj = new_conv
-        
-        self.Stabilizer = Stabilization_Network_Cross_Attention(in_channels=[64, 128, 320, 512], 
+
+        self.Stabilizer = Stabilization_Network_Cross_Attention(in_channels=[64, 128, 320, 512],
                     in_index=[0, 1, 2, 3],
                     feature_strides=[4, 8, 16, 32],
                     channels=128,
@@ -51,15 +51,15 @@ class NVDS(nn.Module):
                                   nn.ReLU(inplace=True))
         self.edge_conv1 = nn.Sequential(nn.Conv2d(in_channels=64, out_channels=128, kernel_size=3, padding=1, stride=2, bias=True),\
                                   nn.ReLU(inplace=True))
-        
-        
-                    
+
+
+
     def forward(self, inputs, num_clips=None, imgs=None):
-    
+
         edge_feat = self.edge_conv(inputs[:,-1,0:-1,:,:])
         edge_feat1 = self.edge_conv1(edge_feat)
-    
-        x = self.backbone(inputs)  
+
+        x = self.backbone(inputs)
         outputs = self.Stabilizer(x,edge_feat,edge_feat1,num_clips=4)
         outputs = F.relu(outputs)
 


### PR DESCRIPTION
To simplify usage by users, I removed all redundant references to `mmseg` and `mmcv` which make this repo much harder to install.
I got good results with just the latest PyTorch (2.1.2)

- Commenting out all redundant import from mmseg / mmcv
- changing `resize` method in `stabilization_network`:
```
# from mmseg.ops import resize
from torch.nn.functional import interpolate as resize
```
- some automatic white space trimming (sorry)

Pay attention that some modules will break, like `decode_head.py` - because I commented out imports that might be used internally. What we can do is wrap `mmseg` and `mmcv` imports with a try/except Clause, instead of commenting them out.

Two Notes:
1. I think a one time formatting of the repo could really help code readability, with a simple `black -l 120 .`
2. A simpler inference script with no use of GMFlow or even DPT can be a nice add-on. You just load depth and rgb from directories and compute the stabilized output. I can PR one if it's beneficial. 